### PR TITLE
Fix incorrect invocation context for rng() function

### DIFF
--- a/dist/sumi-hash.js
+++ b/dist/sumi-hash.js
@@ -164,10 +164,9 @@ A collection of hash algorithms. MD5, SHA1, SHA2, SHA3, RFC4122 UUID ver.1, 2, 3
     }
     function rng() {
         var b = array(16), t = shell.crypto || shell.msCrypto, a = shell.Uint8Array, i = 0, r;
-        t = t && t.getRandomValues;
-        if (t && a) {
+        if (t && t.getRandomValues && a) {
             b = new a(16);
-            t(b);
+            t.getRandomValues(b);
         } else for (;i < 16; i++) {
             if ((i & 3) === 0) r = Math.random() * 4294967296;
             b[i] = r >>> ((i & 3) << 3) & 255;

--- a/src/var/rng.js
+++ b/src/var/rng.js
@@ -15,10 +15,9 @@ function rng () {
 		a = shell.Uint8Array,
 		i = 0,
 		r;
-	t = t && t.getRandomValues;
-	if (t && a) {
+	if (t && t.getRandomValues && a) {
 		b = new a(16);
-		t(b);
+		t.getRandomValues(b);
 	}
 	else for (; i < 16; i++) {
 		if ((i & 0x03) === 0) r = Math.random() * 0x100000000;


### PR DESCRIPTION
Similar issue as here: http://stackoverflow.com/a/9678166/1152564

Assigning a native method to a variable directly does not work, we must
make sure the context (this) stays the same for the invocation.

The current behavior is broken at least in Chrome version 48.0.2564.116 and PhantomJS version 1.8. I think there are many more browsers which are broken, too.
