### PR TITLE
Fix library always polluting global object with Hash

### DIFF
--- a/dist/sumi-hash.js
+++ b/dist/sumi-hash.js
@@ -1488,7 +1488,6 @@ A collection of hash algorithms. MD5, SHA1, SHA2, SHA3, RFC4122 UUID ver.1, 2, 3
             return hexCase(state.slice(0, 8).map(output_fn).join(""));
         };
     }();
-    shell.Hash = shell.Hash || Hash;
     cp(Hash, {
         md5: md5,
         rmd160: rmd160,

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ function(
 	keccak32
 ) {'use strict';
 
-shell.Hash = shell.Hash || Hash; cp(Hash, {
+cp(Hash, {
 	md5       : md5,
 	rmd160    : rmd160,
 	sha1      : sha1,


### PR DESCRIPTION
Users who use `sumi-hash` in a browser could use the global `sumiHash`
object exported by the UMD pattern:
https://github.com/rainersu/hash/blob/v1.0.1/dist/sumi-hash.js#L15

It's a bad pattern to always expose items to global namespace.
